### PR TITLE
Latest spigot dev build 1.8 + latest combat-tag reloaded + latest citizens dev build -> error on combat log!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trc202</groupId>
     <artifactId>combattag</artifactId>
-    <version>6.3.0</version>
+    <version>6.3.1-SNAPSHOT</version>
     <name>CombatTag</name>
     <properties>
         <java.version>1.6</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,4 +90,15 @@
             
         </plugins>
     </build>
+    
+    <distributionManagement>
+        <repository>
+            <id>techcable-repo</id>
+            <url>http://repo.techcable.net/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>techcable-repo</id>
+            <url>http://repo.techcable.net/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trc202</groupId>
     <artifactId>combattag</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>6.3.0</version>
     <name>CombatTag</name>
     <properties>
         <java.version>1.6</java.version>

--- a/src/main/java/com/topcat/npclib/NPCManager.java
+++ b/src/main/java/com/topcat/npclib/NPCManager.java
@@ -193,6 +193,11 @@ public class NPCManager implements Listener {
     	PacketPlayOutPlayerInfo packet = new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.ADD_PLAYER, npcs);
     	EntityPlayer player = ((CraftPlayer)event.getPlayer()).getHandle();
     	player.playerConnection.sendPacket(packet);
+    	for (NPC npc : this.npcs.values()) {
+    	    if (npc instanceof HumanNPC) {
+    	        ((HumanNPC)npc).updateEquipment();
+    	    }
+    	}
     }
     
     public NPCNetworkManager getNPCNetworkManager() {

--- a/src/main/java/com/topcat/npclib/NPCUtils.java
+++ b/src/main/java/com/topcat/npclib/NPCUtils.java
@@ -11,8 +11,12 @@ import org.bukkit.inventory.ItemStack;
 
 public class NPCUtils {
 
+    private static double getDefaultRadius() {
+        return Bukkit.getViewDistance() * 16;
+    }
+
     public static void sendPacketNearby(Location location, Packet packet) {
-        sendPacketNearby(location, packet, 64);
+        sendPacketNearby(location, packet, getDefaultRadius());
     }
 
     public static void sendPacketNearby(Location location, Packet packet, double radius) {
@@ -27,6 +31,27 @@ public class NPCUtils {
             }
 
             ((CraftPlayer) p).getHandle().playerConnection.sendPacket(packet);
+        }
+    }
+    
+    public static void sendPacketsNearby(Location location, Packet... packets) {
+        sendPacketsNearby(location, packets, getDefaultRadius());
+    }
+    
+    public static void sendPacketsNearby(Location location, Packet[] packets, double radius) {
+        radius *= radius;
+        final World world = location.getWorld();
+        for (Player p : Bukkit.getServer().getOnlinePlayers()) {
+            if (p == null || world != p.getWorld()) {
+                continue;
+            }
+            if (location.distanceSquared(p.getLocation()) > radius) {
+                continue;
+            }
+            
+            for (Packet packet : packets) {
+                ((CraftPlayer) p).getHandle().playerConnection.sendPacket(packet);
+            }
         }
     }
 

--- a/src/main/java/com/topcat/npclib/entity/HumanNPC.java
+++ b/src/main/java/com/topcat/npclib/entity/HumanNPC.java
@@ -1,12 +1,15 @@
 package com.topcat.npclib.entity;
 
+import net.minecraft.server.v1_8_R1.Packet;
 import net.minecraft.server.v1_8_R1.PacketPlayOutAnimation;
+import net.minecraft.server.v1_8_R1.PacketPlayOutEntityEquipment;
 import net.minecraft.server.v1_8_R1.WorldServer;
 
 import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.ItemStack;
 
+import com.topcat.npclib.NPCUtils;
 import com.topcat.npclib.nms.NPCEntity;
 
 public class HumanNPC extends NPC {
@@ -20,10 +23,26 @@ public class HumanNPC extends NPC {
     }
 
     public void setItemInHand(Material m, short damage) {
-        ((HumanEntity) getEntity().getBukkitEntity()).setItemInHand(new ItemStack(m, 1, damage));
+        getBukkitEntity().setItemInHand(new ItemStack(m, 1, damage));
     }
 
     public String getName() {
         return ((NPCEntity) getEntity()).getName(); // CHANGED 1.6.1
+    }
+    
+    public NPCEntity getEntity() {
+        return (NPCEntity) super.getEntity();
+    }
+    
+    public void updateEquipment() {
+        Packet[] packets = new Packet[5];
+	    for (int i = 0; i < 5; i++) {
+	        packets[i] = new PacketPlayOutEntityEquipment(getEntity().getId(), i, getEntity().getEquipment(i));
+	    }
+	    NPCUtils.sendPacketsNearby(getBukkitEntity().getLocation());
+    }
+    
+    public HumanEntity getBukkitEntity() {
+        return (HumanEntity) getEntity().getBukkitEntity();
     }
 }

--- a/src/main/java/com/trc202/CombatTag/CombatTag.java
+++ b/src/main/java/com/trc202/CombatTag/CombatTag.java
@@ -34,6 +34,7 @@ import org.bukkit.util.StringUtil;
 import com.google.common.collect.ImmutableList;
 import com.topcat.npclib.NPCManager;
 import com.topcat.npclib.entity.NPC;
+import com.topcat.npclib.entity.HumanNPC;
 import com.trc202.CombatTagEvents.NpcDespawnEvent;
 import com.trc202.CombatTagEvents.NpcDespawnReason;
 import com.trc202.CombatTagListeners.CombatTagCommandPrevention;
@@ -238,6 +239,9 @@ public class CombatTag extends JavaPlugin {
         if (npc.getBukkitEntity() instanceof Player) {
             Player playerNPC = (Player) npc.getBukkitEntity();
             copyTo(playerNPC, plr);
+            if (npc instanceof HumanNPC) {
+                ((HumanNPC)npc).updateEquipment();
+            }
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: CombatTag
-version: 6.3.0
+version: 6.3.1-SNAPSHOT
 author: cheddar262
 main: com.trc202.CombatTag.CombatTag
 dev-url: http://dev.bukkit.org/server-mods/combat-tag

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: CombatTag
-version: 6.3.0-SNAPSHOT
+version: 6.3.0
 author: cheddar262
 main: com.trc202.CombatTag.CombatTag
 dev-url: http://dev.bukkit.org/server-mods/combat-tag


### PR DESCRIPTION
[22:04:51] [Server thread/INFO]: anticos lost connection: Disconnected
[22:04:51] [Server thread/INFO]: [0;37;22mDer Siedler anticos hat sich zur Ruhe gelegt.[m
[22:04:51] [Server thread/ERROR]: Could not pass event CombatLogEvent to CombatTagReloaded v1.0.12
org.bukkit.event.EventException
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:305) ~[spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:502) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:487) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at techcable.minecraft.combattag.Utils.fire(Utils.java:63) [CombatTag.jar:?]
	at techcable.minecraft.combattag.listeners.PlayerListener.onQuit(PlayerListener.java:82) [CombatTag.jar:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.7.0_71]
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.7.0_71]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.7.0_71]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.7.0_71]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:301) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:502) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:487) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.PlayerList.disconnect(PlayerList.java:313) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.PlayerConnection.a(PlayerConnection.java:832) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.NetworkManager.l(NetworkManager.java:242) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.ServerConnection.c(ServerConnection.java:79) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.MinecraftServer.z(MinecraftServer.java:785) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.DedicatedServer.z(DedicatedServer.java:316) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.MinecraftServer.y(MinecraftServer.java:623) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at net.minecraft.server.v1_8_R1.MinecraftServer.run(MinecraftServer.java:526) [spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	at java.lang.Thread.run(Unknown Source) [?:1.7.0_71]
Caused by: java.lang.NullPointerException
	at techcable.minecraft.combattag.libs.techcable.minecraft.npclib.citizens.CitizensNPC.spawn(CitizensNPC.java:56) ~[?:?]
	at techcable.minecraft.combattag.entity.CombatTagNPC.spawn(CombatTagNPC.java:50) ~[?:?]
	at techcable.minecraft.combattag.listeners.NPCListener.onCombatLog(NPCListener.java:21) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.7.0_71]
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.7.0_71]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.7.0_71]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.7.0_71]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:301) ~[spigot.jar:git-Spigot-fa7cbf9-59dd2dd]
	... 22 more
